### PR TITLE
fixed portal spawning mechanism

### DIFF
--- a/lib/game.py
+++ b/lib/game.py
@@ -142,10 +142,14 @@ class Game():
             if self.has_portal == False and random_num <= SPAWN_PORTAL_PROB and self.check_snake_not_on_portal():
                 self.has_portal = True
                 self.portal_enterable = True
-                self.portal_1.randomize(self.snake.body)
-                self.portal_2.randomize(self.snake.body)
-                self.portal_3.randomize(self.snake.body)
-                self.portal_4.randomize(self.snake.body)
+                portal_pos = [self.apple.pos]
+                self.portal_1.randomize(self.snake.body, portal_pos)
+                portal_pos.append(self.portal_1.pos)
+                self.portal_2.randomize(self.snake.body, portal_pos)
+                portal_pos.append(self.portal_2.pos)
+                self.portal_3.randomize(self.snake.body, portal_pos)
+                portal_pos.append(self.portal_3.pos)
+                self.portal_4.randomize(self.snake.body, portal_pos)
 
     def check_snake_not_on_portal(self):
         for body_blk in self.snake.body:

--- a/lib/item.py
+++ b/lib/item.py
@@ -51,10 +51,10 @@ class Portal(Item):
     def __init__(self, size_per_cell, cell_num):
         super().__init__(size_per_cell, 'resources/portal.png', cell_num)
 
-    def randomize(self, snake_body):
+    def randomize(self, snake_body, items_pos):
         self.x = random.randint(1, self.cell_num - 2)
         self.y = random.randint(1, self.cell_num - 2)
         self.pos = Vector2(self.x, self.y)
 
-        while self.pos in snake_body:
-            self.randomize(snake_body)
+        while self.pos in snake_body or self.pos in items_pos:
+            self.randomize(snake_body, items_pos)


### PR DESCRIPTION
The game now guarantees that no apples will spawn on the snake body and portals, and no portals will spawn on the snake body and apple. (location-wise)

Test:
(base) weixuansun@wirelessprv-10-193-38-105 course-project-purdue-hotties % python3 -m pytest -v
============================== test session starts ===============================
platform darwin -- Python 3.9.0, pytest-7.2.2, pluggy-1.0.0 -- /Library/Frameworks/Python.framework/Versions/3.9/bin/python3
cachedir: .pytest_cache
rootdir: /Users/weixuansun/Desktop/dev/purdue hotties/course-project-purdue-hotties
plugins: mock-3.10.0, cov-4.0.0
collected 10 items                                                               

test/item_test.py::test_init PASSED                                        [ 10%]
test/item_test.py::test_exit PASSED                                        [ 20%]
test/item_test.py::test_apple PASSED                                       [ 30%]
test/item_test.py::test_portal PASSED                                      [ 40%]
test/item_test.py::test_draw_item PASSED                                   [ 50%]
test/snake_test.py::test_init PASSED                                       [ 60%]
test/snake_test.py::test_exit PASSED                                       [ 70%]
test/snake_test.py::test_snake PASSED                                      [ 80%]
test/snake_test.py::test_draw_snake PASSED                                 [ 90%]
test/snake_test.py::test_move_snake PASSED                                 [100%]